### PR TITLE
test: Add unit tests for parser and errors (Phase 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build && npm test -- --run"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.2",

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RecToSpecError,
+  ParserError,
+  LLMError,
+} from '@/utils/errors.js';
+
+describe('Error Classes', () => {
+  describe('RecToSpecError', () => {
+    it('should create error with message and code', () => {
+      const error = new RecToSpecError('Test error', 'TEST_ERROR');
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Test error');
+      expect(error.code).toBe('TEST_ERROR');
+      expect(error.name).toBe('RecToSpecError');
+      expect(error.stack).toBeDefined();
+    });
+  });
+
+  describe('ParserError', () => {
+    it('should create parser error with correct code', () => {
+      const error = new ParserError('Invalid JSON format');
+
+      expect(error).toBeInstanceOf(RecToSpecError);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Invalid JSON format');
+      expect(error.code).toBe('PARSER_ERROR');
+      expect(error.name).toBe('ParserError');
+    });
+  });
+
+  describe('LLMError', () => {
+    it('should create LLM error with provider property', () => {
+      const error = new LLMError('API request failed', 'google');
+
+      expect(error).toBeInstanceOf(RecToSpecError);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('API request failed');
+      expect(error.code).toBe('LLM_ERROR');
+      expect(error.name).toBe('LLMError');
+      expect(error.provider).toBe('google');
+    });
+  });
+});

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { parseRecording } from '@/parser/chrome-recorder.js';
+import { ParserError } from '@/utils/errors.js';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('parseRecording', () => {
+  describe('valid Chrome Recorder JSON', () => {
+    it('should parse valid recording with multiple steps', () => {
+      // Load login.json fixture
+      const fixturePath = join(__dirname, '../fixtures/recordings/login.json');
+      const loginRecording = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+
+      const result = parseRecording(loginRecording);
+
+      expect(result.title).toBe('Login flow');
+      expect(result.steps).toBeDefined();
+      expect(result.steps.length).toBeGreaterThan(0);
+      expect(result.metadata).toBeDefined();
+      expect(result.metadata.url).toBe('https://example.com/login');
+      expect(result.metadata.stepCount).toBe(result.steps.length);
+    });
+
+    it('should extract URL from navigate step', () => {
+      const recording = {
+        title: 'Test',
+        steps: [
+          {
+            type: 'navigate',
+            url: 'https://test.com',
+          },
+        ],
+      };
+
+      const result = parseRecording(recording);
+
+      expect(result.metadata.url).toBe('https://test.com');
+    });
+
+    it('should convert click step correctly', () => {
+      const recording = {
+        title: 'Click test',
+        steps: [
+          {
+            type: 'navigate',
+            url: 'https://example.com',
+          },
+          {
+            type: 'click',
+            selectors: [['#button'], ['button.primary']],
+          },
+        ],
+      };
+
+      const result = parseRecording(recording);
+
+      const clickStep = result.steps.find((s) => s.type === 'click');
+      expect(clickStep).toBeDefined();
+      expect(clickStep?.type).toBe('click');
+      expect(clickStep?.selector).toBe('#button'); // First selector chain's last element
+      expect(clickStep?.description).toContain('Click element');
+    });
+
+    it('should convert change step correctly', () => {
+      const recording = {
+        title: 'Form test',
+        steps: [
+          {
+            type: 'navigate',
+            url: 'https://example.com',
+          },
+          {
+            type: 'change',
+            value: 'test@example.com',
+            selectors: [['#email'], ['input[name="email"]']],
+          },
+        ],
+      };
+
+      const result = parseRecording(recording);
+
+      const changeStep = result.steps.find((s) => s.type === 'change');
+      expect(changeStep).toBeDefined();
+      expect(changeStep?.type).toBe('change');
+      expect(changeStep?.value).toBe('test@example.com');
+      expect(changeStep?.selector).toBe('#email'); // First selector chain's last element
+      expect(changeStep?.description).toContain('Enter "test@example.com"');
+    });
+  });
+
+  describe('invalid Chrome Recorder JSON', () => {
+    it('should throw ParserError for invalid schema', () => {
+      const invalidRecording = {
+        // Missing required 'title' field
+        steps: [
+          {
+            type: 'navigate',
+            url: 'https://example.com',
+          },
+        ],
+      };
+
+      expect(() => parseRecording(invalidRecording)).toThrow(ParserError);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'json', 'lcov'],
+      exclude: ['node_modules', 'dist', 'tests/fixtures'],
+      all: true,
+      include: ['src/**/*.ts'],
+    },
+    alias: {
+      '@': '/Users/kataokakenta/works/rectospec/src',
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Add minimal test configuration to establish quality assurance for npm publication process. This is Phase 1 of the test implementation plan, focusing on the most critical modules with minimal dependencies.

## Changes

### Test Infrastructure
- ✅ Create `vitest.config.ts` with ESM and coverage setup
- ✅ Configure path aliases (`@/*` → `src/*`)
- ✅ Set up v8 coverage provider

### Test Files
- ✅ `tests/unit/parser.test.ts` - 5 test cases
  - Valid Chrome Recording parsing (using login.json fixture)
  - URL extraction from navigate step
  - Click step conversion
  - Change step conversion
  - Invalid schema error handling

- ✅ `tests/unit/errors.test.ts` - 3 test cases
  - RecToSpecError basic behavior
  - ParserError creation
  - LLMError with provider property

### Package Configuration
- ✅ Update `package.json` prepublishOnly script to include tests
  - Now runs: `npm run build && npm test -- --run`

## Coverage Results

| File | Coverage | Target |
|------|----------|--------|
| parser/chrome-recorder.ts | 84.09% | 70%+ ✓ |
| parser/types.ts | 100% | - |
| utils/errors.ts | 83.78% | 60%+ ✓ |

## Test Results

```
✓ tests/unit/errors.test.ts (3 tests)
✓ tests/unit/parser.test.ts (5 tests)

Test Files  2 passed (2)
     Tests  8 passed (8)
```

## Future Work (Phase 2+)

- File system utils tests
- Config manager tests (with singleton reset)
- LLM provider tests (with API mocking)
- CLI command integration tests

## Verification

```bash
npm test              # All 8 tests pass
npm run test:coverage # Coverage reports generated
npm run prepublishOnly # Build + test workflow succeeds
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)