### PR TITLE
feat: Add AI-powered Gherkin suggestion backend (PR #5)

### DIFF
--- a/src/llm/prompts/suggestion-prompt.ts
+++ b/src/llm/prompts/suggestion-prompt.ts
@@ -1,0 +1,77 @@
+export interface SuggestionOptions {
+  currentContent: string;
+  language: 'ja' | 'en';
+  focusArea?: 'clarity' | 'completeness' | 'best-practices' | 'all';
+}
+
+/**
+ * Build prompt for Gherkin improvement suggestions
+ */
+export function buildSuggestionPrompt(options: SuggestionOptions): string {
+  const { currentContent, language, focusArea = 'all' } = options;
+
+  const focusInstructions = getFocusInstructions(focusArea);
+
+  return `You are an experienced QA engineer and an expert in BDD (Behavior-Driven Development) and Gherkin.
+
+## Task
+Analyze the following Gherkin file content and provide improvement suggestions.
+
+## Current Gherkin
+\`\`\`gherkin
+${currentContent}
+\`\`\`
+
+## Focus Area
+${focusInstructions}
+
+## Output Requirements
+- Output the improved Gherkin code only
+- Use \`# Language: ${language}\` at the beginning
+- ${language === 'ja' ? 'Write all scenario names and steps in Japanese' : 'Write all scenario names and steps in English'}
+- No explanation text is needed
+
+## Output Format
+\`\`\`gherkin
+# Language: ${language}
+[Improved Gherkin]
+\`\`\`
+
+Output the complete Gherkin file in a markdown code block.`;
+}
+
+/**
+ * Get focus-specific instructions based on the focus area
+ */
+function getFocusInstructions(focusArea: string): string {
+  switch (focusArea) {
+    case 'clarity':
+      return `Focus on clarity improvements:
+- Make scenario names more clear and specific
+- Clarify step descriptions
+- Eliminate ambiguous expressions
+- Use consistent terminology`;
+
+    case 'completeness':
+      return `Focus on completeness improvements:
+- Add missing preconditions
+- Describe Then (expected results) specifically
+- Add edge case scenarios if appropriate
+- Use data tables to improve coverage`;
+
+    case 'best-practices':
+      return `Focus on best practice improvements:
+- Use Background/Scenario Outline/Examples appropriately
+- Follow the one scenario one purpose principle
+- Properly distinguish Given/When/Then roles
+- Focus on behavior rather than implementation details`;
+
+    case 'all':
+    default:
+      return `Comprehensive improvements:
+- Clarity: Make scenario names and steps understandable
+- Completeness: Add missing preconditions and expected results
+- Best Practices: Follow Gherkin principles in structure
+- Maintainability: Use consistent terminology and structure`;
+  }
+}

--- a/src/server/routes/suggestion-api.ts
+++ b/src/server/routes/suggestion-api.ts
@@ -1,0 +1,96 @@
+import { Router, Request, Response } from 'express';
+import { generateSuggestion } from '../../llm/provider.js';
+import { SuggestionOptions } from '../../llm/prompts/suggestion-prompt.js';
+import { LLMError } from '../../utils/errors.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Suggestion API router for AI-powered Gherkin improvements
+ */
+export const suggestionApiRouter = Router();
+
+/**
+ * POST /api/suggest - Generate Gherkin improvement suggestions
+ * Request body:
+ *   - content: Current Gherkin content
+ *   - language: Output language (ja/en)
+ *   - focusArea: Focus area for improvements (optional)
+ */
+suggestionApiRouter.post('/suggest', async (req: Request, res: Response) => {
+  try {
+    const { content, language, focusArea } = req.body;
+
+    // Validation
+    if (!content) {
+      res.status(400).json({
+        error: 'Content is required',
+        message: 'Please provide Gherkin content in the request body',
+      });
+      return;
+    }
+
+    if (!language || !['ja', 'en'].includes(language)) {
+      res.status(400).json({
+        error: 'Invalid language',
+        message: 'Language must be either "ja" or "en"',
+      });
+      return;
+    }
+
+    if (
+      focusArea &&
+      !['clarity', 'completeness', 'best-practices', 'all'].includes(focusArea)
+    ) {
+      res.status(400).json({
+        error: 'Invalid focus area',
+        message:
+          'Focus area must be one of: clarity, completeness, best-practices, all',
+      });
+      return;
+    }
+
+    // Build options
+    const options: SuggestionOptions = {
+      currentContent: content,
+      language: language as 'ja' | 'en',
+      focusArea: focusArea || 'all',
+    };
+
+    logger.info(
+      `Generating suggestion (language: ${language}, focus: ${options.focusArea})`
+    );
+
+    // Generate suggestion
+    const suggestion = await generateSuggestion(options);
+
+    logger.info('Suggestion generated successfully');
+
+    res.json({
+      success: true,
+      suggestion,
+      language,
+      focusArea: options.focusArea,
+    });
+  } catch (error) {
+    if (error instanceof LLMError) {
+      logger.error(`LLM error: ${error.message}`);
+      res.status(500).json({
+        error: 'Failed to generate suggestion',
+        message: error.message,
+        provider: error.provider,
+      });
+    } else if (error instanceof Error) {
+      logger.error(`Unexpected error: ${error.message}`);
+      res.status(500).json({
+        error: 'Internal server error',
+        message: error.message,
+      });
+    } else {
+      logger.error('Unknown error in suggestion API');
+      res.status(500).json({
+        error: 'Internal server error',
+        message: 'Unknown error occurred',
+      });
+    }
+  }
+});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -6,6 +6,7 @@ import { ServerConfig, ServerConfigSchema, ServerInstance } from './types.js';
 import { findAvailablePort } from '../utils/port-finder.js';
 import { logger } from '../utils/logger.js';
 import { fileApiRouter } from './routes/file-api.js';
+import { suggestionApiRouter } from './routes/suggestion-api.js';
 
 // Get current directory in ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -49,6 +50,9 @@ export class EditorServer {
 
     // File API routes
     this.app.use('/api', fileApiRouter);
+
+    // Suggestion API routes
+    this.app.use('/api', suggestionApiRouter);
   }
 
   /**

--- a/tests/server/routes/suggestion-api.test.ts
+++ b/tests/server/routes/suggestion-api.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EditorServer } from '../../../src/server/server.js';
+import { ServerInstance } from '../../../src/server/types.js';
+
+// Mock the LLM provider
+vi.mock('../../../src/llm/provider.js', () => ({
+  generateSuggestion: vi.fn(),
+}));
+
+import { generateSuggestion } from '../../../src/llm/provider.js';
+
+describe('Suggestion API', () => {
+  let server: EditorServer;
+  let instance: ServerInstance | null = null;
+
+  beforeEach(async () => {
+    // Start server on port 9300
+    server = new EditorServer({ port: 9300 });
+    instance = await server.start();
+
+    // Reset mock
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    // Shutdown server
+    if (instance) {
+      await server.shutdown();
+      instance = null;
+    }
+  });
+
+  describe('POST /api/suggest', () => {
+    it('should generate suggestion successfully', async () => {
+      const mockSuggestion = `# Language: en
+Feature: User Login
+  As a user
+  I want to login to the system
+  So that I can access my account
+
+  Scenario: Successful login with valid credentials
+    Given I am on the login page
+    When I enter email "user@example.com"
+    And I enter password "password123"
+    And I click the login button
+    Then I should be redirected to the dashboard`;
+
+      // Setup mock
+      vi.mocked(generateSuggestion).mockResolvedValue(mockSuggestion);
+
+      const response = await fetch(`${instance!.url}/api/suggest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: 'Feature: Login\n  Scenario: Login',
+          language: 'en',
+          focusArea: 'clarity',
+        }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.suggestion).toBe(mockSuggestion);
+      expect(data.language).toBe('en');
+      expect(data.focusArea).toBe('clarity');
+
+      // Verify generateSuggestion was called with correct options
+      expect(generateSuggestion).toHaveBeenCalledWith({
+        currentContent: 'Feature: Login\n  Scenario: Login',
+        language: 'en',
+        focusArea: 'clarity',
+      });
+    });
+
+    it('should use default focusArea when not provided', async () => {
+      const mockSuggestion = 'Feature: Test';
+
+      vi.mocked(generateSuggestion).mockResolvedValue(mockSuggestion);
+
+      const response = await fetch(`${instance!.url}/api/suggest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: 'Feature: Test',
+          language: 'en',
+        }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.focusArea).toBe('all');
+
+      expect(generateSuggestion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          focusArea: 'all',
+        })
+      );
+    });
+
+    it('should return 400 if content is missing', async () => {
+      const response = await fetch(`${instance!.url}/api/suggest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          language: 'en',
+        }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Content is required');
+    });
+
+    it('should return 400 if language is invalid', async () => {
+      const response = await fetch(`${instance!.url}/api/suggest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: 'Feature: Test',
+          language: 'fr',
+        }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Invalid language');
+    });
+
+    it('should return 400 if focusArea is invalid', async () => {
+      const response = await fetch(`${instance!.url}/api/suggest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: 'Feature: Test',
+          language: 'en',
+          focusArea: 'invalid',
+        }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Invalid focus area');
+    });
+
+    it('should return 500 on LLM error', async () => {
+      // Setup mock to throw error
+      vi.mocked(generateSuggestion).mockRejectedValue(
+        new Error('LLM API error')
+      );
+
+      const response = await fetch(`${instance!.url}/api/suggest`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content: 'Feature: Test',
+          language: 'en',
+        }),
+      });
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.error).toBe('Internal server error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement POST /api/suggest endpoint for AI-powered Gherkin improvement suggestions
- Use English-only prompts for better LLM accuracy (language control via `# Language: ja/en` directive)
- Support multiple focus areas: clarity, completeness, best-practices, all
- Add comprehensive tests with mocked LLM provider (6 test cases)

## Changes

### New Files
- `src/llm/prompts/suggestion-prompt.ts` - Suggestion prompt templates with English-only prompts
- `src/server/routes/suggestion-api.ts` - REST API endpoint for AI suggestions
- `tests/server/routes/suggestion-api.test.ts` - Comprehensive API tests (6 scenarios)

### Modified Files
- `src/llm/provider.ts` - Added `generateSuggestion()` function
- `src/server/server.ts` - Registered suggestion API routes

## Technical Details

### API Endpoint
**POST /api/suggest**

Request body:
```json
{
  "content": "Feature: Login\n  Scenario: Login",
  "language": "en",  // "ja" or "en"
  "focusArea": "clarity"  // optional: "clarity" | "completeness" | "best-practices" | "all"
}
```

Response:
```json
{
  "success": true,
  "suggestion": "# Language: en\nFeature: User Login\n  ...",
  "language": "en",
  "focusArea": "clarity"
}
```

### Focus Areas
- **clarity**: Make scenario names more clear and specific
- **completeness**: Add missing preconditions and expected results
- **best-practices**: Follow Gherkin principles in structure
- **all**: Comprehensive improvements (default)

### English-Only Prompts
All prompts are written in English for better LLM accuracy. The output language is controlled via:
- `# Language: ja` directive for Japanese output
- `# Language: en` directive for English output

This approach provides better accuracy than bilingual prompts.

## Tests
All 43 tests passing:
- 6 new tests for suggestion API:
  - ✅ Generate suggestion successfully
  - ✅ Use default focusArea when not provided
  - ✅ Return 400 if content is missing
  - ✅ Return 400 if language is invalid
  - ✅ Return 400 if focusArea is invalid
  - ✅ Return 500 on LLM error

## Test plan
- [ ] Verify POST /api/suggest returns valid suggestions
- [ ] Test with different focus areas (clarity, completeness, best-practices, all)
- [ ] Test with both Japanese and English output languages
- [ ] Verify error handling for invalid inputs
- [ ] Confirm all tests pass: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)